### PR TITLE
Add SO_MARK TCP option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ log = "0.4.11"
 env_logger = "0.8"
 futures = "0.3.5"
 structopt = "0.3.16"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = "0.20"


### PR DESCRIPTION
This adds an `fwmark` option to `TcpOptions`, primarily for setting `SO_MARK` on the "forwarding" TCP socket in `Udp2Tcp`. This is useful in applying different routing and nftables/iptables rules to the TCP socket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/1)
<!-- Reviewable:end -->
