### PR TITLE
Set SO_MARK on socket before connecting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-tokio = { version = "0.2.22", features = ["rt-threaded", "macros", "tcp", "udp", "io-util"] }
+tokio = { version = "0.2.22", features = ["blocking", "rt-threaded", "macros", "tcp", "udp", "io-util"] }
 err-context = "0.1.0"
 log = "0.4.11"
 env_logger = "0.7.1"


### PR DESCRIPTION
`SO_MARK` needs to be set before connecting to the TCP server. This is not possible using tokio 0.2 without a temporary workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/2)
<!-- Reviewable:end -->
