### PR TITLE
Require one tcp listen addr

### DIFF
--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -26,8 +26,10 @@ pub struct Options {
     pub tcp_options: crate::tcp_options::TcpOptions,
 }
 
+/// Error returned from [`run`] if something goes wrong.
 #[derive(Debug)]
 pub enum Tcp2UdpError {
+    /// No TCP listen addresses given in the `Options`.
     NoTcpListenAddrs,
 }
 
@@ -49,6 +51,8 @@ impl std::error::Error for Tcp2UdpError {
     }
 }
 
+/// Runs the TCP to UDP forwarding until the TCP socket is closed or an
+/// error occurs.
 pub async fn run(options: Options) -> Result<(), Box<dyn std::error::Error>> {
     if options.tcp_listen_addrs.is_empty() {
         return Err(Box::new(Tcp2UdpError::NoTcpListenAddrs));

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -9,8 +9,9 @@ use tokio::net::{TcpListener, TcpSocket, TcpStream, UdpSocket};
 
 #[derive(Debug, StructOpt)]
 pub struct Options {
-    /// The IP and TCP port to listen to for incoming traffic from udp2tcp.
-    #[structopt(long = "tcp-listen")]
+    /// The IP and TCP port(s) to listen to for incoming traffic from udp2tcp.
+    /// Supports binding multiple TCP sockets.
+    #[structopt(long = "tcp-listen", required(true))]
     pub tcp_listen_addrs: Vec<SocketAddr>,
 
     #[structopt(long = "udp-forward")]
@@ -25,10 +26,34 @@ pub struct Options {
     pub tcp_options: crate::tcp_options::TcpOptions,
 }
 
+#[derive(Debug)]
+pub enum Tcp2UdpError {
+    NoTcpListenAddrs,
+}
+
+impl fmt::Display for Tcp2UdpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Tcp2UdpError::*;
+        match self {
+            NoTcpListenAddrs => "Invalid options, no TCP listen addresses".fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Tcp2UdpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Tcp2UdpError::*;
+        match self {
+            NoTcpListenAddrs => None,
+        }
+    }
+}
+
 pub async fn run(options: Options) -> Result<(), Box<dyn std::error::Error>> {
     if options.tcp_listen_addrs.is_empty() {
-        todo!("Properly handle no TCP listening addresses given");
+        return Err(Box::new(Tcp2UdpError::NoTcpListenAddrs));
     }
+
     let mut join_handles = Vec::with_capacity(options.tcp_listen_addrs.len());
     for tcp_listen_addr in options.tcp_listen_addrs {
         let tcp_listener = create_listening_socket(tcp_listen_addr, &options.tcp_options)?;


### PR DESCRIPTION
First commit: Just extracts Tokio runtime creation to separate function. Just for cleanliness.

Second commit: Makes the `tcp2udp` binary require at least one TCP listen addr. Before now it would just panic if none was given. And also the `--help` output was worse than it is now.

This also introduces a new error type. For now we still return the opaque `Box<dyn Error>` type. That's because I did not feel like completely refactoring all errors at once. But at least this allows me to return what was previously a panic as a "real" error. `Tcp2UdpError` an be extended with more structured error variants later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/4)
<!-- Reviewable:end -->
