### PR TITLE
Improve tcp2udp return types and documentation

### DIFF
--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -27,6 +27,7 @@ fn main() {
         log::error!("Error: {}", error.display("\nCaused by: "));
         std::process::exit(1);
     }
+    unreachable!("tcp2udp never returns");
 }
 
 /// Creates a Tokio runtime for the process to use.

--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -1,4 +1,4 @@
-use err_context::BoxedErrorExt as _;
+use err_context::ErrorExt as _;
 use std::num::NonZeroU8;
 use structopt::StructOpt;
 

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -4,6 +4,7 @@
 use err_context::{BoxedErrorExt as _, ResultExt as _};
 use std::convert::Infallible;
 use std::fmt;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 use structopt::StructOpt;
 use tokio::net::{TcpListener, TcpSocket, TcpStream, UdpSocket};
@@ -32,6 +33,15 @@ pub struct Options {
 pub enum Tcp2UdpError {
     /// No TCP listen addresses given in the `Options`.
     NoTcpListenAddrs,
+    CreateTcpSocket(io::Error),
+    /// Failed to apply TCP options to socket.
+    ApplyTcpOptions(crate::tcp_options::ApplyTcpOptionsError),
+    /// Failed to enable `SO_REUSEADDR` on TCP socket
+    SetReuseAddr(io::Error),
+    /// Failed to bind TCP socket to SocketAddr
+    BindTcpSocket(io::Error, SocketAddr),
+    /// Failed to start listening on TCP socket
+    ListenTcpSocket(io::Error, SocketAddr),
 }
 
 impl fmt::Display for Tcp2UdpError {
@@ -39,6 +49,15 @@ impl fmt::Display for Tcp2UdpError {
         use Tcp2UdpError::*;
         match self {
             NoTcpListenAddrs => "Invalid options, no TCP listen addresses".fmt(f),
+            CreateTcpSocket(_) => "Failed to create TCP socket".fmt(f),
+            ApplyTcpOptions(_) => "Failed to apply options to TCP socket".fmt(f),
+            SetReuseAddr(_) => "Failed to set SO_REUSEADDR on TCP socket".fmt(f),
+            BindTcpSocket(_, addr) => write!(f, "Failed to bind TCP socket to {}", addr),
+            ListenTcpSocket(_, addr) => write!(
+                f,
+                "Failed to start listening on TCP socket bound to {}",
+                addr
+            ),
         }
     }
 }
@@ -48,6 +67,11 @@ impl std::error::Error for Tcp2UdpError {
         use Tcp2UdpError::*;
         match self {
             NoTcpListenAddrs => None,
+            CreateTcpSocket(e) => Some(e),
+            ApplyTcpOptions(e) => Some(e),
+            SetReuseAddr(e) => Some(e),
+            BindTcpSocket(e, _) => Some(e),
+            ListenTcpSocket(e, _) => Some(e),
         }
     }
 }
@@ -56,9 +80,9 @@ impl std::error::Error for Tcp2UdpError {
 /// If binding a listening socket fails this returns an error. Otherwise the function
 /// will continue indefinitely to accept incoming connections and forward to UDP.
 /// Errors are just logged.
-pub async fn run(options: Options) -> Result<Infallible, Box<dyn std::error::Error>> {
+pub async fn run(options: Options) -> Result<Infallible, Tcp2UdpError> {
     if options.tcp_listen_addrs.is_empty() {
-        return Err(Box::new(Tcp2UdpError::NoTcpListenAddrs));
+        return Err(Tcp2UdpError::NoTcpListenAddrs);
     }
 
     let mut join_handles = Vec::with_capacity(options.tcp_listen_addrs.len());
@@ -79,20 +103,22 @@ pub async fn run(options: Options) -> Result<Infallible, Box<dyn std::error::Err
 fn create_listening_socket(
     addr: SocketAddr,
     options: &crate::tcp_options::TcpOptions,
-) -> Result<TcpListener, Box<dyn std::error::Error>> {
+) -> Result<TcpListener, Tcp2UdpError> {
     let tcp_socket = match addr {
         SocketAddr::V4(..) => TcpSocket::new_v4(),
         SocketAddr::V6(..) => TcpSocket::new_v6(),
     }
-    .context("Failed to create new TCP socket")?;
-    crate::tcp_options::apply(&tcp_socket, options)?;
+    .map_err(Tcp2UdpError::CreateTcpSocket)?;
+    crate::tcp_options::apply(&tcp_socket, options).map_err(Tcp2UdpError::ApplyTcpOptions)?;
     tcp_socket
         .set_reuseaddr(true)
-        .context("Failed to set SO_REUSEADDR on TCP socket")?;
+        .map_err(Tcp2UdpError::SetReuseAddr)?;
     tcp_socket
         .bind(addr)
-        .with_context(|_| format!("Failed to bind TCP socket to {}", addr))?;
-    let tcp_listener = tcp_socket.listen(1024)?;
+        .map_err(|e| Tcp2UdpError::BindTcpSocket(e, addr))?;
+    let tcp_listener = tcp_socket
+        .listen(1024)
+        .map_err(|e| Tcp2UdpError::ListenTcpSocket(e, addr))?;
 
     Ok(tcp_listener)
 }

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -104,8 +104,6 @@ async fn process_tcp_listener(
             Ok((tcp_stream, tcp_peer_addr)) => {
                 log::debug!("Incoming connection from {}/TCP", tcp_peer_addr);
 
-                let udp_bind_ip = udp_bind_ip;
-                let udp_forward_addr = udp_forward_addr;
                 tokio::spawn(async move {
                     if let Err(error) =
                         process_socket(tcp_stream, tcp_peer_addr, udp_bind_ip, udp_forward_addr)


### PR DESCRIPTION
I realized a few things were actually diverging functions, never returning. But their documentation said otherwise, and their types did not hint at this either. So I tried to fix that. What do you think of this way to better signal when/how things abort (they don't)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/6)
<!-- Reviewable:end -->
