### PR TITLE
Change Option<TcpOptions> to just TcpOptions

### DIFF
--- a/src/bin/udp2tcp.rs
+++ b/src/bin/udp2tcp.rs
@@ -33,7 +33,7 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error>> {
     let udp2tcp = udp2tcp::Udp2Tcp::new(
         options.udp_listen_addr,
         options.tcp_forward_addr,
-        Some(options.tcp_options),
+        options.tcp_options,
     )
     .await?;
     udp2tcp.run().await?;

--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -81,10 +81,9 @@ impl Udp2Tcp {
     pub async fn new(
         udp_listen_addr: SocketAddr,
         tcp_forward_addr: SocketAddr,
-        tcp_options: Option<crate::TcpOptions>,
+        tcp_options: crate::TcpOptions,
     ) -> Result<Self, ConnectError> {
-        let tcp_stream =
-            Self::connect_tcp_socket(tcp_forward_addr, tcp_options.unwrap_or_default()).await?;
+        let tcp_stream = Self::connect_tcp_socket(tcp_forward_addr, tcp_options).await?;
         log::info!("Connected to {}/TCP", tcp_forward_addr);
 
         let udp_socket = UdpSocket::bind(udp_listen_addr)


### PR DESCRIPTION
The rationale is that `TcpOptions::default()` looks better than `None` when calling the function. Our binary always had a `TcpOptions` at hand anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/7)
<!-- Reviewable:end -->
