### PR TITLE
Use Infallible more extensively in return types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,3 +85,15 @@ mod forward_traffic;
 mod tcp_options;
 
 pub use tcp_options::{ApplyTcpOptionsError, TcpOptions};
+
+/// Helper trait for `Result<Infallible, E>` types. Allows getting the `E` value
+/// in a way that is guaranteed to not panic.
+pub trait NeverOkResult<E> {
+    fn into_err(self) -> E;
+}
+
+impl<E> NeverOkResult<E> for Result<std::convert::Infallible, E> {
+    fn into_err(self) -> E {
+        self.expect_err("Result<Infallible, _> can't be Ok variant")
+    }
+}


### PR DESCRIPTION
As you pointed out in the previous PR, more return types could make use of `Infallible`. As I started implementing that I realized a helper trait could eliminate some code paths and make some code more readable. So I added that. It has to be a public trait in order for `src/bin/tcp2udp.rs` to use it.

I also corrected/added some more documentation to code and functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/8)
<!-- Reviewable:end -->
