### PR TITLE
Add possibility to redact logging via env var REDACT_LOGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "env_logger",
  "err-context",
  "futures",
+ "lazy_static",
  "log",
  "nix",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4.11"
 env_logger = "0.8"
 futures = "0.3.5"
 structopt = "0.3.16"
+lazy_static = "1.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.20"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A library (and binaries) for tunneling UDP datagrams over a TCP stream.
 Some programs/protocols only work over UDP. And some networks only allow TCP. This is where
 `udp-over-tcp` comes in handy. This library comes in two parts:
 
-* `udp2tcp` - Forwards incoming UDP datagrams and over a TCP stream. The return stream
-  is translated back to datagrams and send out over UDP again.
+* `udp2tcp` - Forwards incoming UDP datagrams over a TCP stream. The return stream
+  is translated back to datagrams and sent back out over UDP again.
   This part can be easily used as both a library and a binary.
   So it can be run standalone, but can also easily be included in other
   Rust programs. The UDP socket is connected to the peer address of the first incoming
@@ -36,6 +36,9 @@ user@server $ RUST_LOG=debug tcp2udp \
 
 `RUST_LOG` can be used to set logging level. See documentation for [`env_logger`] for
 information.
+
+`REDACT_LOGS=1` can be set to redact the IPs of the peers using the service from the logs.
+Allows having logging turned on but without storing potentially user sensitive data to disk.
 
 [`env_logger`]: https://crates.io/crates/env_logger
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub mod udp2tcp;
 pub use udp2tcp::Udp2Tcp;
 
 mod forward_traffic;
+mod logging;
 mod tcp_options;
 
 pub use tcp_options::{ApplyTcpOptionsError, TcpOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@
 //! `RUST_LOG` can be used to set logging level. See documentation for [`env_logger`] for
 //! information.
 //!
+//! `REDACT_LOGS=1` can be set to redact the IPs of the peers using the service from the logs.
+//! Allows having logging turned on but without storing potentially user sensitive data to disk.
+//!
 //! [`env_logger`]: https://crates.io/crates/env_logger
 //!
 //! # udp2tcp example

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+lazy_static::lazy_static! {
+    /// If true, redact IPs and other user sensitive data from logs
+    static ref REDACT_LOGS: bool = std::env::var("REDACT_LOGS")
+        .map(|v| v != "0")
+        .unwrap_or(false);
+}
+
+/// Wrap any displayable type in this to have its Display/Debug format be redacted at runtime
+/// if the user so wish. Makes it possible to log more extensively without collecting user
+/// sensitivie data.
+pub struct Redact<T>(pub T);
+
+impl<T: fmt::Display> fmt::Display for Redact<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *REDACT_LOGS {
+            true => write!(f, "[REDACTED]"),
+            false => self.0.fmt(f),
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Redact<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *REDACT_LOGS {
+            true => write!(f, "[REDACTED]"),
+            false => self.0.fmt(f),
+        }
+    }
+}

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -1,6 +1,7 @@
 //! Primitives for listening on TCP and forwarding the data in incoming connections
 //! to UDP.
 
+use crate::logging::Redact;
 use err_context::{BoxedErrorExt as _, ResultExt as _};
 use std::convert::Infallible;
 use std::fmt;
@@ -131,7 +132,7 @@ async fn process_tcp_listener(
     loop {
         match tcp_listener.accept().await {
             Ok((tcp_stream, tcp_peer_addr)) => {
-                log::debug!("Incoming connection from {}/TCP", tcp_peer_addr);
+                log::debug!("Incoming connection from {}/TCP", Redact(tcp_peer_addr));
 
                 tokio::spawn(async move {
                     if let Err(error) =
@@ -180,7 +181,7 @@ async fn process_socket(
     crate::forward_traffic::process_udp_over_tcp(udp_socket, tcp_stream).await;
     log::debug!(
         "Closing forwarding for {}/TCP <-> {}/UDP",
-        tcp_peer_addr,
+        Redact(tcp_peer_addr),
         udp_peer_addr
     );
 

--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -1,6 +1,7 @@
 //! Primitives for listening on UDP and forwarding the data in incoming datagrams
 //! to a TCP stream.
 
+use crate::logging::Redact;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
@@ -136,7 +137,7 @@ impl Udp2Tcp {
             .peek_from(&mut [0u8; crate::forward_traffic::MAX_DATAGRAM_SIZE])
             .await
             .map_err(ForwardError::ReadUdp)?;
-        log::info!("Incoming connection from {}/UDP", udp_peer_addr);
+        log::info!("Incoming connection from {}/UDP", Redact(udp_peer_addr));
 
         // Connect the UDP socket to whoever sent the first datagram. This is where
         // all the returned traffic will be sent to.
@@ -148,7 +149,7 @@ impl Udp2Tcp {
         crate::forward_traffic::process_udp_over_tcp(self.udp_socket, self.tcp_stream).await;
         log::debug!(
             "Closing forwarding for {}/UDP <-> {}/TCP",
-            udp_peer_addr,
+            Redact(udp_peer_addr),
             self.tcp_forward_addr,
         );
 

--- a/tcp2udp.service
+++ b/tcp2udp.service
@@ -12,7 +12,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Environment=RUST_LOG=info
+# Uncomment this to have the logs not contain the IPs of the peers using this service
+#Environment=REDACT_LOGS=1
+Environment=RUST_LOG=debug
 ExecStart=/usr/local/bin/tcp2udp --threads=2 --tcp-listen 0.0.0.0:443 --udp-bind=127.0.0.1 --udp-forward 127.0.0.1:51820
 Restart=always
 RestartSec=2


### PR DESCRIPTION
Enables logging verbosely without capturing the IPs of the peers using the proxy service. To allow running the server part without storing user sensitive data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/11)
<!-- Reviewable:end -->
