### PR TITLE
Forbid all unsafe code

### DIFF
--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use err_context::ErrorExt as _;
 use std::num::NonZeroU8;
 use structopt::StructOpt;

--- a/src/bin/udp2tcp.rs
+++ b/src/bin/udp2tcp.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use err_context::BoxedErrorExt as _;
 use std::net::SocketAddr;
 use structopt::StructOpt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@
 //! ```
 //!
 
+#![forbid(unsafe_code)]
 #![deny(clippy::all)]
 
 pub mod tcp2udp;


### PR DESCRIPTION
I realized we don't have any unsafe code at the moment. And if we can avoid it we should not use it in the future neither. This crate does not really do much that would justify unsafe code right now. So I felt it was better to have this safeguard now and if we later want to introduce `unsafe` we need to justify it well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/12)
<!-- Reviewable:end -->
