### PR TITLE
Upgrade env logger and make it optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,13 @@ codegen-units = 1
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 err-context = "0.1.0"
 log = "0.4.11"
-env_logger = "0.8"
 futures = "0.3.5"
 structopt = "0.3.16"
 lazy_static = "1.4.0"
+
+# Only used by the binaries in src/bin/ and is optional so it's not
+# pulled in when built as a library.
+env_logger = { version = "0.9", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.23.1"

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ let tcp_forward_addr = "1.2.3.4:9000".parse().unwrap();
 
 // Create a UDP -> TCP forwarder. This will connect the TCP socket
 // to `tcp_forward_addr`
-let udp2tcp = udp2tcp::Udp2Tcp::new(
+let udp2tcp = udp_over_tcp::Udp2Tcp::new(
     udp_listen_addr,
     tcp_forward_addr,
-    TcpOptions::default(),
+    udp_over_tcp::TcpOptions::default(),
 )
 .await?;
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ user@server $ RUST_LOG=debug tcp2udp \
 ```
 
 `RUST_LOG` can be used to set logging level. See documentation for [`env_logger`] for
-information.
+information. The crate must be built with the `env_logger` feature for this to be active.
 
 `REDACT_LOGS=1` can be set to redact the IPs of the peers using the service from the logs.
 Allows having logging turned on but without storing potentially user sensitive data to disk.

--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -19,7 +19,9 @@ pub struct Options {
 }
 
 fn main() {
+    #[cfg(feature = "env_logger")]
     env_logger::init();
+
     let options = Options::from_args();
 
     let runtime = create_runtime(options.threads);

--- a/src/bin/udp2tcp.rs
+++ b/src/bin/udp2tcp.rs
@@ -23,7 +23,9 @@ pub struct Options {
 
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "env_logger")]
     env_logger::init();
+
     let options = Options::from_args();
     if let Err(error) = run(options).await {
         log::error!("Error: {}", error.display("\nCaused by: "));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! ```
 //!
 //! `RUST_LOG` can be used to set logging level. See documentation for [`env_logger`] for
-//! information.
+//! information. The crate must be built with the `env_logger` feature for this to be active.
 //!
 //! `REDACT_LOGS=1` can be set to redact the IPs of the peers using the service from the logs.
 //! Allows having logging turned on but without storing potentially user sensitive data to disk.


### PR DESCRIPTION
I saw that there was a new release of `env_logger`. So I figured we could upgrade. We should provide a new build of `tcp2udp` to infra rather soon anyway, so better get on the latest stuff.

I then also realized that the library depends on `env_logger`. It's not very nice of *libraries* to pull in loggers. One potential solution to this would be to put the binaries in separate crates and avoid the dependency completely in `udp-over-tcp`. But that was way more boilerplate and overhead than making it optional like this PR does. Activating the feature when building the library does absolutely nothing. Is this an OK compromise compared to the separate crates in your opinion?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/19)
<!-- Reviewable:end -->
