### PR TITLE
Add a script to easily build the binaries statically linked

### DIFF
--- a/build-static-bins.sh
+++ b/build-static-bins.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Use this script to compile the binaries statically linked for Linux
+# and with logging enabled (controlled by RUST_LOG env var)
+#
+# You need the static version of glibc installed for this to work.
+# On Fedora/RHEL that's: glibc-static.
+# On Debian/Ubuntu that's: libc6-dev.
+
+RUSTFLAGS="-C target-feature=+crt-static" \
+    cargo build --release \
+    --target x86_64-unknown-linux-gnu \
+    --features env_logger \
+    --bins


### PR DESCRIPTION
When deploying this to the infrastructure we want it statically linked. We also want logging to be turned on. So there is a hefty set of flags one must pass to get the correct results. I figured it would be way easier to build and to build in the same way every time if we add a script for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/20)
<!-- Reviewable:end -->
