### PR TITLE
Add LimitNOFILE=16384 to the example tcp2udp.service

### DIFF
--- a/tcp2udp.service
+++ b/tcp2udp.service
@@ -12,10 +12,16 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+# Raise the soft limit on number of open file handles.
+# This needs to be at least two times the number of
+# wanted simultaneous client connections.
+LimitNOFILE=16384
+
 # Uncomment this to have the logs not contain the IPs of the peers using this service
 #Environment=REDACT_LOGS=1
 Environment=RUST_LOG=debug
 ExecStart=/usr/local/bin/tcp2udp --threads=2 --tcp-listen 0.0.0.0:443 --udp-bind=127.0.0.1 --udp-forward 127.0.0.1:51820
+
 Restart=always
 RestartSec=2
 


### PR DESCRIPTION
Shows how to run the service with a raised soft limit
on the number of open FDs. Since the default is pretty
often low, and the service should be able to handle
many simultaneous connections

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/23)
<!-- Reviewable:end -->
