### PR TITLE
Add TCP recv timeout option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "io-util"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "time", "io-util"] }
 err-context = "0.1.0"
 log = "0.4.11"
 futures = "0.3.5"

--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -51,6 +51,7 @@ fn create_runtime(threads: Option<NonZeroU8>) -> tokio::runtime::Runtime {
         }
         None => tokio::runtime::Builder::new_multi_thread(),
     };
+    runtime.enable_time();
     runtime.enable_io();
 
     runtime.build().expect("Failed to build async runtime")

--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -16,7 +16,7 @@ use tokio::time::timeout;
 
 /// A UDP datagram header has a 16 bit field containing an unsigned integer
 /// describing the length of the datagram (including the header itself).
-/// The max value is 2^16 = 65534 bytes. But since that includes the
+/// The max value is 2^16 = 65536 bytes. But since that includes the
 /// UDP header, this constant is 8 bytes more than any UDP socket
 /// read operation would ever return. We are going to use that extra space
 /// to store our 2 byte udp-over-tcp header.

--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -4,12 +4,15 @@ use err_context::ResultExt as _;
 use futures::future::select;
 use futures::pin_mut;
 use std::convert::{Infallible, TryFrom};
+use std::future::Future;
 use std::io;
 use std::mem;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf as TcpReadHalf, OwnedWriteHalf as TcpWriteHalf};
 use tokio::net::{TcpStream, UdpSocket};
+use tokio::time::timeout;
 
 /// A UDP datagram header has a 16 bit field containing an unsigned integer
 /// describing the length of the datagram (including the header itself).
@@ -23,13 +26,17 @@ const HEADER_LEN: usize = mem::size_of::<u16>();
 /// Forward traffic between the given UDP and TCP sockets in both directions.
 /// This async function runs until one of the sockets are closed or there is an error.
 /// Both sockets are closed before returning.
-pub async fn process_udp_over_tcp(udp_socket: UdpSocket, tcp_stream: TcpStream) {
+pub async fn process_udp_over_tcp(
+    udp_socket: UdpSocket,
+    tcp_stream: TcpStream,
+    tcp_recv_timeout: Option<Duration>,
+) {
     let udp_in = Arc::new(udp_socket);
     let udp_out = udp_in.clone();
     let (tcp_in, tcp_out) = tcp_stream.into_split();
 
     let tcp2udp = async move {
-        if let Err(error) = process_tcp2udp(tcp_in, udp_out).await {
+        if let Err(error) = process_tcp2udp(tcp_in, udp_out, tcp_recv_timeout).await {
             log::error!("Error: {}", error.display("\nCaused by: "));
         }
     };
@@ -50,15 +57,17 @@ pub async fn process_udp_over_tcp(udp_socket: UdpSocket, tcp_stream: TcpStream) 
 async fn process_tcp2udp(
     mut tcp_in: TcpReadHalf,
     udp_out: Arc<UdpSocket>,
+    tcp_recv_timeout: Option<Duration>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut buffer = datagram_buffer();
     // `buffer` has unprocessed data from the TCP socket up until this index.
     let mut unprocessed_i = 0;
     loop {
-        let tcp_read_len = tcp_in
-            .read(&mut buffer[unprocessed_i..])
-            .await
-            .context("Failed reading from TCP")?;
+        let tcp_read_len =
+            maybe_timeout(tcp_recv_timeout, tcp_in.read(&mut buffer[unprocessed_i..]))
+                .await
+                .context("Timeout while reading from TCP")?
+                .context("Failed reading from TCP")?;
         if tcp_read_len == 0 {
             break;
         }
@@ -77,6 +86,16 @@ async fn process_tcp2udp(
     }
     log::debug!("TCP socket closed");
     Ok(())
+}
+
+async fn maybe_timeout<F: Future>(
+    duration: Option<Duration>,
+    future: F,
+) -> Result<F::Output, tokio::time::error::Elapsed> {
+    match duration {
+        Some(duration) => timeout(duration, future).await,
+        None => Ok(future.await),
+    }
 }
 
 /// Forward all complete datagrams in `buffer` to `udp_out`.

--- a/tcp2udp.service
+++ b/tcp2udp.service
@@ -20,7 +20,7 @@ LimitNOFILE=16384
 # Uncomment this to have the logs not contain the IPs of the peers using this service
 #Environment=REDACT_LOGS=1
 Environment=RUST_LOG=debug
-ExecStart=/usr/local/bin/tcp2udp --threads=2 --tcp-listen 0.0.0.0:443 --udp-bind=127.0.0.1 --udp-forward 127.0.0.1:51820
+ExecStart=/usr/local/bin/tcp2udp --threads=2 --tcp-listen 0.0.0.0:443 --udp-bind=127.0.0.1 --udp-forward 127.0.0.1:51820 --tcp-recv-timeout=130
 
 Restart=always
 RestartSec=2


### PR DESCRIPTION
This PR adds an optional read timeout for `tcp2udp`. It does not touch any socket options but simply uses `tokio::time::timeout`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/24)
<!-- Reviewable:end -->
