### PR TITLE
Make structopt optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           default: true
 
-      - name: Build
-        uses: actions-rs/cargo@v1
+      - name: Install cargo-all-features
+        uses: actions-rs/install@v0.1
         with:
-          command: build
+          crate: cargo-all-features
+          version: latest
+          use-tool-cache: true
+
+      - name: Build
+        run: cargo build-all-features
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test-all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "udp-over-tcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "env_logger",
  "err-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,14 @@ repository = "https://github.com/mullvad/udp-over-tcp"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "tcp2udp"
+required-features = ["structopt"]
+
+[[bin]]
+name = "udp2tcp"
+required-features = ["structopt"]
+
 [profile.release]
 opt-level = 3
 lto = true
@@ -18,7 +26,7 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "time
 err-context = "0.1.0"
 log = "0.4.11"
 futures = "0.3.5"
-structopt = "0.3.16"
+structopt = { version = "0.3.16", optional = true }
 lazy_static = "1.4.0"
 
 # Only used by the binaries in src/bin/ and is optional so it's not

--- a/build-static-bins.sh
+++ b/build-static-bins.sh
@@ -11,4 +11,5 @@ RUSTFLAGS="-C target-feature=+crt-static" \
     cargo build --release \
     --target x86_64-unknown-linux-gnu \
     --features env_logger \
+    --features structopt \
     --bins

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -8,25 +8,28 @@ use std::fmt;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
-use structopt::StructOpt;
 use tokio::net::{TcpListener, TcpSocket, TcpStream, UdpSocket};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug)]
+#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
 pub struct Options {
     /// The IP and TCP port(s) to listen to for incoming traffic from udp2tcp.
     /// Supports binding multiple TCP sockets.
-    #[structopt(long = "tcp-listen", required(true))]
+    #[cfg_attr(feature = "structopt", structopt(long = "tcp-listen", required(true)))]
     pub tcp_listen_addrs: Vec<SocketAddr>,
 
-    #[structopt(long = "udp-forward")]
+    #[cfg_attr(feature = "structopt", structopt(long = "udp-forward"))]
     /// The IP and UDP port to forward all traffic to.
     pub udp_forward_addr: SocketAddr,
 
     /// Which local IP to bind the UDP socket to.
-    #[structopt(long = "udp-bind", default_value = "0.0.0.0")]
+    #[cfg_attr(
+        feature = "structopt",
+        structopt(long = "udp-bind", default_value = "0.0.0.0")
+    )]
     pub udp_bind_ip: IpAddr,
 
-    #[structopt(flatten)]
+    #[cfg_attr(feature = "structopt", structopt(flatten))]
     pub tcp_options: crate::tcp_options::TcpOptions,
 }
 

--- a/src/tcp_options.rs
+++ b/src/tcp_options.rs
@@ -2,34 +2,33 @@
 use nix::sys::socket::{getsockopt, setsockopt, sockopt};
 use std::fmt;
 use std::io;
-use std::num::ParseIntError;
 #[cfg(target_os = "linux")]
 use std::os::unix::io::AsRawFd;
-use std::str::FromStr;
 use std::time::Duration;
 use tokio::net::TcpSocket;
 
 /// Options to apply to the TCP socket involved in the tunneling.
-#[derive(Debug, Default, Clone, structopt::StructOpt)]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
 pub struct TcpOptions {
     /// If given, sets the SO_RCVBUF option on the TCP socket to the given number of bytes.
     /// Changes the size of the operating system's receive buffer associated with the socket.
-    #[structopt(long = "recv-buffer")]
+    #[cfg_attr(feature = "structopt", structopt(long = "recv-buffer"))]
     pub recv_buffer_size: Option<u32>,
 
     /// If given, sets the SO_SNDBUF option on the TCP socket to the given number of bytes.
     /// Changes the size of the operating system's send buffer associated with the socket.
-    #[structopt(long = "send-buffer")]
+    #[cfg_attr(feature = "structopt", structopt(long = "send-buffer"))]
     pub send_buffer_size: Option<u32>,
 
     /// An application timeout on receiving data from the TCP socket.
-    #[structopt(long = "tcp-recv-timeout", parse(try_from_str = duration_secs_from_str))]
+    #[cfg_attr(feature = "structopt", structopt(long = "tcp-recv-timeout", parse(try_from_str = duration_secs_from_str)))]
     pub recv_timeout: Option<Duration>,
 
     /// If given, sets the SO_MARK option on the TCP socket.
     /// This exists only on Linux.
     #[cfg(target_os = "linux")]
-    #[structopt(long = "fwmark")]
+    #[cfg_attr(feature = "structopt", structopt(long = "fwmark"))]
     pub fwmark: Option<u32>,
 }
 
@@ -71,7 +70,9 @@ impl std::error::Error for ApplyTcpOptionsError {
     }
 }
 
-fn duration_secs_from_str(str_duration: &str) -> Result<Duration, ParseIntError> {
+#[cfg(feature = "structopt")]
+fn duration_secs_from_str(str_duration: &str) -> Result<Duration, std::num::ParseIntError> {
+    use std::str::FromStr;
     u64::from_str(str_duration).map(Duration::from_secs)
 }
 


### PR DESCRIPTION
I realize that structopt pulls in clap 2.x. And in our main repo we use clap 3.x.. So this will allow us to cut the dependency tree a bit.. Also, a library should not depend on a crate used to create CLIs...

Fixes #25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/26)
<!-- Reviewable:end -->
