### PR TITLE
Replace audit check on PR push with periodical job

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,13 @@
+name: Security audit
+on:
+  schedule:
+    # Run at 06:00 UTC every morning
+    - cron: '0 6 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,25 +38,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  audit:
+  security_audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/audit-check@v1
         with:
-          profile: minimal
-          toolchain: stable
-          default: true
-      - name: Install cargo-audit
-        uses: actions-rs/install@v0.1.2
-        with:
-          crate: cargo-audit
-          version: latest
-          use-tool-cache: true
-      - name: Audit
-        run: cargo audit --deny warnings
-
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-test:
     strategy:


### PR DESCRIPTION
While fiddling with the CI and checking out the https://github.com/actions-rs organization for various Rust related Github Actions actions I found the `audit-check` action. Seems way simpler to use than the way we installed and ran `cargo audit`.

I'm adding this both as a scheduled job *and* on each PR. It's relevant in PRs if the PR changes the dependency tree. And it's relevant as a scheduled job since CVEs can pop up at any time even when the dependency tree is not changing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/27)
<!-- Reviewable:end -->
