### PR TITLE
Choose correct address family for UDP socket when `udp-bind` is not specified explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
-
+### Fixed
+- When `tcp2udp` is run, select the address family for the UDP socket based on the
+  destination address. Previously, `AF_INET` was always used by default.
 
 ## [0.2.0] - 2022-03-23
 ### Added


### PR DESCRIPTION
`udp-bind` defaults to `0.0.0.0` for `tcp2udp`. This means that `AF_INET` is used as the address family even if the destination is an IPv6 address. This PR fixes this by binding the socket to `::` by default if the destination is an IPv6 address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/28)
<!-- Reviewable:end -->
