### PR TITLE
Add option to connect to TCP endpoint when the first UDP datagram is received

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
           version: latest
           use-tool-cache: true
       - name: Audit
-        run: cargo audit --deny warnings
+        # Ignore warning about ansi_term being unmaintained
+        run: cargo audit --deny warnings --ignore RUSTSEC-2021-0139
 
 
   build-and-test:

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -195,7 +195,7 @@ async fn process_socket(
             .local_addr()
             .ok()
             .as_ref()
-            .map(|item| -> &dyn fmt::Display { &*item })
+            .map(|item| -> &dyn fmt::Display { item })
             .unwrap_or(&"unknown"),
         udp_peer_addr
     );

--- a/src/tcp_options.rs
+++ b/src/tcp_options.rs
@@ -25,6 +25,10 @@ pub struct TcpOptions {
     #[cfg_attr(feature = "structopt", structopt(long = "tcp-recv-timeout", parse(try_from_str = duration_secs_from_str)))]
     pub recv_timeout: Option<Duration>,
 
+    /// If true, wait for the first incoming UDP datagram before connecting to the TCP endpoint.
+    #[cfg_attr(feature = "structopt", structopt(skip))]
+    pub lazy_connect: bool,
+
     /// If given, sets the SO_MARK option on the TCP socket.
     /// This exists only on Linux.
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
This is useful for obtaining the UDP address of the `Udp2Tcp` instance before connecting to the TCP endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/32)
<!-- Reviewable:end -->
