### PR TITLE
Add method for obtaining the raw TCP socket file descriptor

### DIFF
--- a/src/tcp_options.rs
+++ b/src/tcp_options.rs
@@ -25,10 +25,6 @@ pub struct TcpOptions {
     #[cfg_attr(feature = "clap", arg(long = "tcp-recv-timeout", value_parser = duration_secs_from_str))]
     pub recv_timeout: Option<Duration>,
 
-    /// If true, wait for the first incoming UDP datagram before connecting to the TCP endpoint.
-    #[cfg_attr(feature = "clap", arg(skip))]
-    pub lazy_connect: bool,
-
     /// If given, sets the SO_MARK option on the TCP socket.
     /// This exists only on Linux.
     #[cfg(target_os = "linux")]

--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -7,6 +7,9 @@ use std::io;
 use std::net::SocketAddr;
 use tokio::net::{TcpSocket, TcpStream, UdpSocket};
 
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+
 #[derive(Debug)]
 pub enum ConnectError {
     /// Failed to create the TCP socket.
@@ -74,7 +77,7 @@ impl std::error::Error for ForwardError {
 
 /// Struct allowing listening on UDP and forwarding the traffic over TCP.
 pub struct Udp2Tcp {
-    tcp_stream: Option<TcpStream>,
+    tcp_socket: TcpForwardSocket,
     udp_socket: UdpSocket,
     tcp_forward_addr: SocketAddr,
     tcp_options: crate::TcpOptions,
@@ -89,11 +92,10 @@ impl Udp2Tcp {
         tcp_forward_addr: SocketAddr,
         tcp_options: crate::TcpOptions,
     ) -> Result<Self, ConnectError> {
-        let tcp_stream = if !tcp_options.lazy_connect {
-            Some(Self::connect_tcp_socket(tcp_forward_addr, &tcp_options).await?)
-        } else {
-            None
-        };
+        let mut tcp_socket = TcpForwardSocket::new(tcp_forward_addr, &tcp_options)?;
+        if !tcp_options.lazy_connect {
+            tcp_socket = TcpForwardSocket::Stream(tcp_socket.connect().await?);
+        }
 
         let udp_socket = UdpSocket::bind(udp_listen_addr)
             .await
@@ -104,33 +106,11 @@ impl Udp2Tcp {
         }
 
         Ok(Self {
-            tcp_stream,
+            tcp_socket,
             udp_socket,
             tcp_forward_addr,
             tcp_options,
         })
-    }
-
-    async fn connect_tcp_socket(
-        addr: SocketAddr,
-        options: &crate::TcpOptions,
-    ) -> Result<TcpStream, ConnectError> {
-        let tcp_socket = match addr {
-            SocketAddr::V4(..) => TcpSocket::new_v4(),
-            SocketAddr::V6(..) => TcpSocket::new_v6(),
-        }
-        .map_err(ConnectError::CreateTcpSocket)?;
-
-        crate::tcp_options::apply(&tcp_socket, options).map_err(ConnectError::ApplyTcpOptions)?;
-
-        let tcp_stream = tcp_socket
-            .connect(addr)
-            .await
-            .map_err(ConnectError::ConnectTcp)?;
-
-        log::info!("Connected to {}/TCP", addr);
-
-        Ok(tcp_stream)
     }
 
     /// Returns the UDP address this instance is listening on for incoming datagrams to forward.
@@ -141,8 +121,14 @@ impl Udp2Tcp {
         self.udp_socket.local_addr()
     }
 
+    /// Returns the raw file descriptor for the TCP socket that datagrams are forwarded to.
+    #[cfg(unix)]
+    pub fn remote_tcp_fd(&self) -> RawFd {
+        self.tcp_socket.as_raw_fd()
+    }
+
     /// Runs the forwarding until the TCP socket is closed, or an error occur.
-    pub async fn run(mut self) -> Result<(), ForwardError> {
+    pub async fn run(self) -> Result<(), ForwardError> {
         // Wait for the first datagram, to get the UDP peer_addr to connect to.
         let mut tmp_buffer = crate::forward_traffic::datagram_buffer();
         let (_udp_read_len, udp_peer_addr) = self
@@ -152,12 +138,11 @@ impl Udp2Tcp {
             .map_err(ForwardError::ReadUdp)?;
         log::info!("Incoming connection from {}/UDP", Redact(udp_peer_addr));
 
-        let tcp_stream = match self.tcp_stream.take() {
-            Some(tcp_stream) => tcp_stream,
-            None => Self::connect_tcp_socket(self.tcp_forward_addr, &self.tcp_options)
-                .await
-                .map_err(ForwardError::ConnectTcp)?,
-        };
+        let tcp_stream = self
+            .tcp_socket
+            .connect()
+            .await
+            .map_err(ForwardError::ConnectTcp)?;
 
         // Connect the UDP socket to whoever sent the first datagram. This is where
         // all the returned traffic will be sent to.
@@ -179,5 +164,54 @@ impl Udp2Tcp {
         );
 
         Ok(())
+    }
+}
+
+enum TcpForwardSocket {
+    Socket((TcpSocket, SocketAddr)),
+    Stream(TcpStream),
+}
+
+impl TcpForwardSocket {
+    fn new(
+        tcp_forward_addr: SocketAddr,
+        options: &crate::TcpOptions,
+    ) -> Result<Self, ConnectError> {
+        let socket = match &tcp_forward_addr {
+            SocketAddr::V4(..) => TcpSocket::new_v4(),
+            SocketAddr::V6(..) => TcpSocket::new_v6(),
+        }
+        .map_err(ConnectError::CreateTcpSocket)?;
+
+        crate::tcp_options::apply(&socket, options).map_err(ConnectError::ApplyTcpOptions)?;
+
+        Ok(TcpForwardSocket::Socket((socket, tcp_forward_addr)))
+    }
+
+    async fn connect(self) -> Result<TcpStream, ConnectError> {
+        match self {
+            TcpForwardSocket::Socket((socket, addr)) => {
+                log::info!("Connecting to {}/TCP", addr);
+
+                let tcp_stream = socket
+                    .connect(addr)
+                    .await
+                    .map_err(ConnectError::ConnectTcp)?;
+
+                log::info!("Connected to {}/TCP", addr);
+                Ok(tcp_stream)
+            }
+            TcpForwardSocket::Stream(stream) => Ok(stream),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for TcpForwardSocket {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            TcpForwardSocket::Socket((sock, _)) => sock.as_raw_fd(),
+            TcpForwardSocket::Stream(stream) => stream.as_raw_fd(),
+        }
     }
 }

--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -5,41 +5,37 @@ use crate::logging::Redact;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
-use tokio::net::{TcpSocket, TcpStream, UdpSocket};
+use tokio::net::{TcpSocket, UdpSocket};
 
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 
 #[derive(Debug)]
-pub enum ConnectError {
+pub enum Error {
     /// Failed to create the TCP socket.
     CreateTcpSocket(io::Error),
-    /// Failed to connect to TCP forward address.
-    ConnectTcp(io::Error),
     /// Failed to apply the given TCP socket options.
     ApplyTcpOptions(crate::tcp_options::ApplyTcpOptionsError),
     /// Failed to bind UDP socket locally.
     BindUdp(io::Error),
 }
 
-impl fmt::Display for ConnectError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ConnectError::*;
+        use Error::*;
         match self {
             CreateTcpSocket(_) => "Failed to create the TCP socket".fmt(f),
-            ConnectTcp(_) => "Failed to connect to TCP forward address".fmt(f),
             ApplyTcpOptions(e) => e.fmt(f),
             BindUdp(_) => "Failed to bind UDP socket locally".fmt(f),
         }
     }
 }
 
-impl std::error::Error for ConnectError {
+impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use ConnectError::*;
+        use Error::*;
         match self {
             CreateTcpSocket(e) => Some(e),
-            ConnectTcp(e) => Some(e),
             ApplyTcpOptions(e) => e.source(),
             BindUdp(e) => Some(e),
         }
@@ -50,7 +46,7 @@ impl std::error::Error for ConnectError {
 pub enum ForwardError {
     ReadUdp(io::Error),
     ConnectUdp(io::Error),
-    ConnectTcp(ConnectError),
+    ConnectTcp(io::Error),
 }
 
 impl fmt::Display for ForwardError {
@@ -59,7 +55,7 @@ impl fmt::Display for ForwardError {
         match self {
             ReadUdp(_) => "Failed receiving the first UDP datagram".fmt(f),
             ConnectUdp(_) => "Failed to connect UDP socket to peer".fmt(f),
-            ConnectTcp(error) => error.fmt(f),
+            ConnectTcp(_) => "Failed to connect to TCP forward address".fmt(f),
         }
     }
 }
@@ -77,29 +73,31 @@ impl std::error::Error for ForwardError {
 
 /// Struct allowing listening on UDP and forwarding the traffic over TCP.
 pub struct Udp2Tcp {
-    tcp_socket: TcpForwardSocket,
+    tcp_socket: TcpSocket,
     udp_socket: UdpSocket,
     tcp_forward_addr: SocketAddr,
     tcp_options: crate::TcpOptions,
 }
 
 impl Udp2Tcp {
-    /// Connects to the given TCP address (unless `TcpOptions::lazy_connect` is true) and binds to
-    /// the given UDP address.
+    /// Creates a TCP socket and binds to the given UDP address.
     /// Just calling this constructor won't forward any traffic over the sockets (see `run`).
     pub async fn new(
         udp_listen_addr: SocketAddr,
         tcp_forward_addr: SocketAddr,
         tcp_options: crate::TcpOptions,
-    ) -> Result<Self, ConnectError> {
-        let mut tcp_socket = TcpForwardSocket::new(tcp_forward_addr, &tcp_options)?;
-        if !tcp_options.lazy_connect {
-            tcp_socket = TcpForwardSocket::Stream(tcp_socket.connect().await?);
+    ) -> Result<Self, Error> {
+        let tcp_socket = match &tcp_forward_addr {
+            SocketAddr::V4(..) => TcpSocket::new_v4(),
+            SocketAddr::V6(..) => TcpSocket::new_v6(),
         }
+        .map_err(Error::CreateTcpSocket)?;
+
+        crate::tcp_options::apply(&tcp_socket, &tcp_options).map_err(Error::ApplyTcpOptions)?;
 
         let udp_socket = UdpSocket::bind(udp_listen_addr)
             .await
-            .map_err(ConnectError::BindUdp)?;
+            .map_err(Error::BindUdp)?;
         match udp_socket.local_addr() {
             Ok(addr) => log::info!("Listening on {}/UDP", addr),
             Err(e) => log::error!("Unable to get UDP local addr: {}", e),
@@ -127,7 +125,8 @@ impl Udp2Tcp {
         self.tcp_socket.as_raw_fd()
     }
 
-    /// Runs the forwarding until the TCP socket is closed, or an error occur.
+    /// Connects to the TCP address and runs the forwarding until the TCP socket is closed, or
+    /// an error occur.
     pub async fn run(self) -> Result<(), ForwardError> {
         // Wait for the first datagram, to get the UDP peer_addr to connect to.
         let mut tmp_buffer = crate::forward_traffic::datagram_buffer();
@@ -138,11 +137,13 @@ impl Udp2Tcp {
             .map_err(ForwardError::ReadUdp)?;
         log::info!("Incoming connection from {}/UDP", Redact(udp_peer_addr));
 
+        log::info!("Connecting to {}/TCP", self.tcp_forward_addr);
         let tcp_stream = self
             .tcp_socket
-            .connect()
+            .connect(self.tcp_forward_addr)
             .await
             .map_err(ForwardError::ConnectTcp)?;
+        log::info!("Connected to {}/TCP", self.tcp_forward_addr);
 
         // Connect the UDP socket to whoever sent the first datagram. This is where
         // all the returned traffic will be sent to.
@@ -164,54 +165,5 @@ impl Udp2Tcp {
         );
 
         Ok(())
-    }
-}
-
-enum TcpForwardSocket {
-    Socket((TcpSocket, SocketAddr)),
-    Stream(TcpStream),
-}
-
-impl TcpForwardSocket {
-    fn new(
-        tcp_forward_addr: SocketAddr,
-        options: &crate::TcpOptions,
-    ) -> Result<Self, ConnectError> {
-        let socket = match &tcp_forward_addr {
-            SocketAddr::V4(..) => TcpSocket::new_v4(),
-            SocketAddr::V6(..) => TcpSocket::new_v6(),
-        }
-        .map_err(ConnectError::CreateTcpSocket)?;
-
-        crate::tcp_options::apply(&socket, options).map_err(ConnectError::ApplyTcpOptions)?;
-
-        Ok(TcpForwardSocket::Socket((socket, tcp_forward_addr)))
-    }
-
-    async fn connect(self) -> Result<TcpStream, ConnectError> {
-        match self {
-            TcpForwardSocket::Socket((socket, addr)) => {
-                log::info!("Connecting to {}/TCP", addr);
-
-                let tcp_stream = socket
-                    .connect(addr)
-                    .await
-                    .map_err(ConnectError::ConnectTcp)?;
-
-                log::info!("Connected to {}/TCP", addr);
-                Ok(tcp_stream)
-            }
-            TcpForwardSocket::Stream(stream) => Ok(stream),
-        }
-    }
-}
-
-#[cfg(unix)]
-impl AsRawFd for TcpForwardSocket {
-    fn as_raw_fd(&self) -> RawFd {
-        match self {
-            TcpForwardSocket::Socket((sock, _)) => sock.as_raw_fd(),
-            TcpForwardSocket::Stream(stream) => stream.as_raw_fd(),
-        }
     }
 }


### PR DESCRIPTION
Useful to have since we want to exclude the socket from the tunnel on Android.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/33)
<!-- Reviewable:end -->
