### PR TITLE
Upgrade env_logger to get rid of atty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,7 @@ jobs:
           version: latest
           use-tool-cache: true
       - name: Audit
-        # The vulnerability affects custom global allocators, so it
-        # should be safe to ignore it. Stop ignoring the warning once
-        # atty has been replaced in clap and env_logger:
-        # https://github.com/clap-rs/clap/pull/4249
-        # https://github.com/rust-cli/env_logger/pull/246
-        run: cargo audit --deny warnings --ignore RUSTSEC-2021-0145
+        run: cargo audit --deny warnings
 
 
   build-and-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,17 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,12 +80,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -223,15 +212,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1.4.0"
 
 # Only used by the binaries in src/bin/ and is optional so it's not
 # pulled in when built as a library.
-env_logger = { version = "0.9", optional = true }
+env_logger = { version = "0.10.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.23.1"


### PR DESCRIPTION
Preparing for a new release (`0.3.0`). But I realized that we ignore `RUSTSEC-2021-0145` and still have `atty` in our dependency tree. It was easy to get rid of however, since we only had to upgrade `env_logger`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/40)
<!-- Reviewable:end -->
