### PR TITLE
Allow getting the crate version from the CLI

### DIFF
--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -7,7 +7,11 @@ use std::num::NonZeroU8;
 use udp_over_tcp::{tcp2udp, NeverOkResult};
 
 #[derive(Debug, Parser)]
-#[command(name = "tcp2udp", about = "Listen for incoming TCP and forward to UDP")]
+#[command(
+    name = "tcp2udp",
+    about = "Listen for incoming TCP and forward to UDP",
+    version
+)]
 pub struct Options {
     /// Sets the number of worker threads to use.
     /// The default value is the number of cores available to the system.

--- a/src/bin/udp2tcp.rs
+++ b/src/bin/udp2tcp.rs
@@ -7,7 +7,11 @@ use std::net::SocketAddr;
 use udp_over_tcp::udp2tcp;
 
 #[derive(Debug, Parser)]
-#[command(name = "udp2tcp", about = "Listen for incoming UDP and forward to TCP")]
+#[command(
+    name = "udp2tcp",
+    about = "Listen for incoming UDP and forward to TCP",
+    version
+)]
 pub struct Options {
     /// The IP and UDP port to bind to and accept incoming connections on.
     #[arg(long = "udp-listen")]


### PR DESCRIPTION
A regression after the migration from `structopt` to `clap 4`: It was no longer possible to get the version of the program from the CLI interface. This adds that back. So infra can check what version they are running.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/41)
<!-- Reviewable:end -->
