### PR TITLE
Add (optional) statsd metrics reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Add (optional) statsd metrics reporting support to `tcp2udp` binary and library module when the
+  `statsd` cargo feature is enabled.
 
 
 ## [0.3.1] - 2023-10-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "cadence"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab51a759f502097abe855100b81b421d3a104b62a2c3209f751d90ce6dd2ea1"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +176,25 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -577,6 +605,7 @@ dependencies = [
 name = "udp-over-tcp"
 version = "0.3.1"
 dependencies = [
+ "cadence",
  "clap",
  "env_logger",
  "err-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ opt-level = 3
 lto = true
 codegen-units = 1
 
+[features]
+# Enable this feature to make it possible to have tcp2udp report metrics over statsd
+statsd = ["cadence"]
+
 [dependencies]
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "time", "io-util"] }
 err-context = "0.1.0"
@@ -32,6 +36,7 @@ lazy_static = "1.4.0"
 # Only used by the binaries in src/bin/ and is optional so it's not
 # pulled in when built as a library.
 env_logger = { version = "0.10.0", optional = true }
+cadence = { version = "1.0.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.27.1", features = ["socket"] }

--- a/build-static-bins.sh
+++ b/build-static-bins.sh
@@ -12,4 +12,5 @@ RUSTFLAGS="-C target-feature=+crt-static" \
     --target x86_64-unknown-linux-gnu \
     --features env_logger \
     --features clap \
+    --features statsd \
     --bins

--- a/src/statsd.rs
+++ b/src/statsd.rs
@@ -128,7 +128,7 @@ mod real {
         }
 
         pub fn incr_connections(&self) {
-            let num_connections = self.num_connections.fetch_add(1, Ordering::SeqCst) + 1;
+            let num_connections = self.num_connections.fetch_add(1, Ordering::Relaxed) + 1;
             log::debug!("Sending statsd num_connections = {num_connections}");
             if let Err(e) = self.client.gauge("num_connections", num_connections) {
                 log::error!("Failed to emit statsd num_connections: {e}");
@@ -136,7 +136,7 @@ mod real {
         }
 
         pub fn decr_connections(&self) {
-            let num_connections = self.num_connections.fetch_sub(1, Ordering::SeqCst) - 1;
+            let num_connections = self.num_connections.fetch_sub(1, Ordering::Relaxed) - 1;
             log::debug!("Sending statsd num_connections = {num_connections}");
             if let Err(e) = self.client.gauge("num_connections", num_connections) {
                 log::error!("Failed to emit statsd num_connections: {e}");

--- a/src/statsd.rs
+++ b/src/statsd.rs
@@ -1,0 +1,146 @@
+#[cfg(feature = "statsd")]
+pub use real::Error;
+
+pub struct StatsdMetrics(StatsdMetricsChooser);
+
+enum StatsdMetricsChooser {
+    Dummy,
+    #[cfg(feature = "statsd")]
+    Real(real::StatsdMetrics),
+}
+
+impl StatsdMetrics {
+    /// Creates a dummy statsd metrics instance. Does not actually connect to any statds
+    /// server, nor emits any events. Used as an API compatible drop in when metrics
+    /// should not be emitted.
+    pub fn dummy() -> Self {
+        Self(StatsdMetricsChooser::Dummy)
+    }
+
+    /// Creates a statsd metric reporting instance connecting to the given host addr.
+    #[cfg(feature = "statsd")]
+    pub fn real(host: std::net::SocketAddr) -> Result<Self, Error> {
+        let statsd = real::StatsdMetrics::new(host)?;
+        Ok(Self(StatsdMetricsChooser::Real(statsd)))
+    }
+
+    /// Emit a metric saying we failed to accept an incoming TCP connection (probably ran out of file descriptors)
+    pub fn accept_error(&self) {
+        #[cfg(feature = "statsd")]
+        if let StatsdMetricsChooser::Real(statsd) = &self.0 {
+            statsd.accept_error()
+        }
+    }
+
+    /// Increment the connection counter inside this metrics instance and emit that new gauge value
+    pub fn incr_connections(&self) {
+        #[cfg(feature = "statsd")]
+        if let StatsdMetricsChooser::Real(statsd) = &self.0 {
+            statsd.incr_connections()
+        }
+    }
+
+    /// Decrement the connection counter inside this metrics instance and emit that new gauge value
+    pub fn decr_connections(&self) {
+        #[cfg(feature = "statsd")]
+        if let StatsdMetricsChooser::Real(statsd) = &self.0 {
+            statsd.decr_connections()
+        }
+    }
+}
+
+#[cfg(feature = "statsd")]
+mod real {
+    use cadence::{CountedExt, Gauged, QueuingMetricSink, StatsdClient, UdpMetricSink};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Queue with a maximum capacity of 8K events.
+    /// This program is extremely unlikely to ever reach that upper bound.
+    /// The bound is still here so that if it ever were to happen, we drop events
+    /// instead of indefinitely filling the memory with unsent events.
+    const QUEUE_SIZE: usize = 8 * 1024;
+
+    const PREFIX: &str = "tcp2udp";
+
+    #[derive(Debug)]
+    pub enum Error {
+        /// Failed to create + bind the statsd UDP socket.
+        BindUdpSocket(std::io::Error),
+        /// Failed to create statsd client.
+        CreateStatsdClient(cadence::MetricError),
+    }
+
+    impl std::fmt::Display for Error {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            use Error::*;
+            match self {
+                BindUdpSocket(_) => "Failed to bind the UDP socket".fmt(f),
+                CreateStatsdClient(e) => e.fmt(f),
+            }
+        }
+    }
+
+    impl std::error::Error for Error {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            use Error::*;
+            match self {
+                BindUdpSocket(e) => Some(e),
+                CreateStatsdClient(e) => e.source(),
+            }
+        }
+    }
+
+    pub struct StatsdMetrics {
+        client: StatsdClient,
+        num_connections: AtomicU64,
+    }
+
+    impl StatsdMetrics {
+        pub fn new(host: std::net::SocketAddr) -> Result<Self, Error> {
+            let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(Error::BindUdpSocket)?;
+            log::debug!(
+                "Statsd socket bound to {}",
+                socket
+                    .local_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|_| "Unknown".to_owned())
+            );
+
+            // Create a non-buffered blocking metrics sink. It is important that it's not buffered,
+            // so events are emitted instantly when they happen (this program does not emit a lot of
+            // events, nor does it attach timestamps to the events.
+            // The fact that it's blocking does not matter, since the `QueuingMetricSink` will make sure
+            // the `UdpMetricSink` runs in its own thread anyway.
+            let udp_sink = UdpMetricSink::from(host, socket).map_err(Error::CreateStatsdClient)?;
+            let queuing_sink = QueuingMetricSink::with_capacity(udp_sink, QUEUE_SIZE);
+            let statds_client = StatsdClient::from_sink(PREFIX, queuing_sink);
+            Ok(Self {
+                client: statds_client,
+                num_connections: AtomicU64::new(0),
+            })
+        }
+
+        pub fn accept_error(&self) {
+            log::debug!("Sending statsd tcp_accept_errors");
+            if let Err(e) = self.client.incr("tcp_accept_errors") {
+                log::error!("Failed to emit statsd tcp_accept_errors: {e}");
+            }
+        }
+
+        pub fn incr_connections(&self) {
+            let num_connections = self.num_connections.fetch_add(1, Ordering::SeqCst) + 1;
+            log::debug!("Sending statsd num_connections = {num_connections}");
+            if let Err(e) = self.client.gauge("num_connections", num_connections) {
+                log::error!("Failed to emit statsd num_connections: {e}");
+            }
+        }
+
+        pub fn decr_connections(&self) {
+            let num_connections = self.num_connections.fetch_sub(1, Ordering::SeqCst) - 1;
+            log::debug!("Sending statsd num_connections = {num_connections}");
+            if let Err(e) = self.client.gauge("num_connections", num_connections) {
+                log::error!("Failed to emit statsd num_connections: {e}");
+            }
+        }
+    }
+}

--- a/tcp2udp.service
+++ b/tcp2udp.service
@@ -20,7 +20,7 @@ LimitNOFILE=16384
 # Uncomment this to have the logs not contain the IPs of the peers using this service
 #Environment=REDACT_LOGS=1
 Environment=RUST_LOG=debug
-ExecStart=/usr/local/bin/tcp2udp --threads=2 --tcp-listen 0.0.0.0:443 --udp-bind=127.0.0.1 --udp-forward 127.0.0.1:51820 --tcp-recv-timeout=130 --nodelay
+ExecStart=/usr/local/bin/tcp2udp --threads=2 --statsd-host 127.0.0.1:8125 --tcp-listen 0.0.0.0:443 --udp-bind=127.0.0.1 --udp-forward 127.0.0.1:51820 --tcp-recv-timeout=130 --nodelay
 
 Restart=always
 RestartSec=2


### PR DESCRIPTION
To better monitor the health of the `tcp2udp` (WireGuard over TCP server side component) service, we should add simple error metrics to it. After discussion with @Rizzly we agreed on adding a counter that shows number of connected clients, and an error event when we fail to accept incoming TCP connections.

I added it in such a way that both the library and the binary can be compiled without statsd support. This makes the entire dependency optional. Just like we have done with `clap` and `env_logger`. This forced me to expose a dummy-layer of the metrics so the code still builds when it's not enabled, and so the metrics callsites did not become too complex (I did not want the metrics reporting to interfere a lot with the actual forwarding logic code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/51)
<!-- Reviewable:end -->
