### PR TITLE
Make growing types non exhaustive

### DIFF
--- a/src/statsd.rs
+++ b/src/statsd.rs
@@ -63,6 +63,7 @@ mod real {
     const PREFIX: &str = "tcp2udp";
 
     #[derive(Debug)]
+    #[non_exhaustive]
     pub enum Error {
         /// Failed to create + bind the statsd UDP socket.
         BindUdpSocket(std::io::Error),

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -39,7 +39,7 @@ pub struct Options {
     #[cfg(feature = "statsd")]
     /// Host to send statsd metrics to.
     #[cfg_attr(feature = "clap", clap(long))]
-    statsd_host: Option<SocketAddr>,
+    pub statsd_host: Option<SocketAddr>,
 }
 
 /// Error returned from [`run`] if something goes wrong.

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -44,6 +44,7 @@ pub struct Options {
 
 /// Error returned from [`run`] if something goes wrong.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Tcp2UdpError {
     /// No TCP listen addresses given in the `Options`.
     NoTcpListenAddrs,

--- a/src/tcp2udp.rs
+++ b/src/tcp2udp.rs
@@ -16,9 +16,15 @@ use tokio::time::sleep;
 #[path = "statsd.rs"]
 mod statsd;
 
-#[derive(Debug)]
+/// Settings for a tcp2udp session. This is the argument to [`run`] to
+/// describe how the forwarding from TCP -> UDP should be set up.
+///
+/// This struct is `non_exhaustive` in order to allow adding more optional fields without
+/// being considered breaking changes. So you need to create an instance via [`Options::new`].
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 #[cfg_attr(feature = "clap", group(skip))]
+#[non_exhaustive]
 pub struct Options {
     /// The IP and TCP port(s) to listen to for incoming traffic from udp2tcp.
     /// Supports binding multiple TCP sockets.
@@ -40,6 +46,38 @@ pub struct Options {
     /// Host to send statsd metrics to.
     #[cfg_attr(feature = "clap", clap(long))]
     pub statsd_host: Option<SocketAddr>,
+}
+
+impl Options {
+    /// Creates a new [`Options`] with all mandatory fields set to the passed arguments.
+    /// All optional values are set to their default values. They can later be set, since
+    /// they are public.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::net::{IpAddr, Ipv4Addr, SocketAddrV4, SocketAddr};
+    ///
+    /// let mut options = udp_over_tcp::tcp2udp::Options::new(
+    ///     // Listen on 127.0.0.1:1234/TCP
+    ///     vec![SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234))],
+    ///     // Forward to 192.0.2.15:5001/UDP
+    ///     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 15), 5001)),
+    /// );
+    ///
+    /// // Bind the local UDP socket (used to send to 192.0.2.15:5001/UDP) to the loopback interface
+    /// options.udp_bind_ip = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    /// ```
+    pub fn new(tcp_listen_addrs: Vec<SocketAddr>, udp_forward_addr: SocketAddr) -> Self {
+        Options {
+            tcp_listen_addrs,
+            udp_forward_addr,
+            udp_bind_ip: None,
+            tcp_options: Default::default(),
+            #[cfg(feature = "statsd")]
+            statsd_host: None,
+        }
+    }
 }
 
 /// Error returned from [`run`] if something goes wrong.

--- a/src/tcp_options.rs
+++ b/src/tcp_options.rs
@@ -35,6 +35,7 @@ pub struct TcpOptions {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ApplyTcpOptionsError {
     /// Failed to get/set TCP_RCVBUF
     RecvBuffer(io::Error),

--- a/src/tcp_options.rs
+++ b/src/tcp_options.rs
@@ -8,6 +8,7 @@ use tokio::net::{TcpSocket, TcpStream};
 /// Options to apply to the TCP socket involved in the tunneling.
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[non_exhaustive]
 pub struct TcpOptions {
     /// If given, sets the SO_RCVBUF option on the TCP socket to the given number of bytes.
     /// Changes the size of the operating system's receive buffer associated with the socket.

--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -11,6 +11,7 @@ use tokio::net::{TcpSocket, UdpSocket};
 use std::os::unix::io::{AsRawFd, RawFd};
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Failed to create the TCP socket.
     CreateTcpSocket(io::Error),


### PR DESCRIPTION
I was about to bump the version and release. Given that we have added an error variant to an enum and a field to a struct it's technically a breaking change even if the feature is off by default... At least I think it should count as that :thinking: Because even if you as a direct user of `udp-over-tcp` does not activate the feature, a transitive dependency might....

The fix for the error enum is easy, make them `#[non_exhaustive]`. I think this is a pretty good default for error enums to begin with. Because it allows adding more error cases without it being a breaking change...

But what about the `Options` struct? I figured the best might be to also make it `#[non_exhaustive]` and provide facilities for users to construct it without hitting compilation errors both if others enable the `statsd` feature OR if we add other optional fields later.

We still need to bump the version in a breaking fashion after this PR (to 0.4.0) but these changes will allow us to stay on `0.4.x` after that even if we add optional option fields or error variants, something we cannot if we don't merge this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/52)
<!-- Reviewable:end -->
