### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,14 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+
+
+## [0.4.0] - 2024-01-02
 ### Changed
 - Add (optional) statsd metrics reporting support to `tcp2udp` binary and library module when the
   `statsd` cargo feature is enabled.
+- Breaking: Make options structs and error enums `#[non_exhaustive]` in order to allow adding more
+  fields to them later without being breaking changes then.
 
 
 ## [0.3.1] - 2023-10-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "udp-over-tcp"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cadence",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udp-over-tcp"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Mullvad VPN"]
 license = "MIT OR Apache-2.0"
 description = "Tunnel UDP traffic inside a TCP stream. Each datagram is prefixed with a 16 bit unsigned integer containing the length"


### PR DESCRIPTION
Let's release #51!

Is a breaking change both since we add fields/variants to existing public types, *and* because we mark some types as `#[non_exhaustive]`. Both of these things cause API breakage compared to version `0.3.1`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/53)
<!-- Reviewable:end -->
