### PR TITLE
Hide details of error implementation, to not make changes into breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Changed
+- Change the public API of `ApplyTcpOptionsError`. So this is a breaking change. This stops
+  exposing the internal details of the type which allows future changes to not be breaking.
 
 
 ## [0.4.0] - 2024-01-02

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ mod forward_traffic;
 mod logging;
 mod tcp_options;
 
-pub use tcp_options::{ApplyTcpOptionsError, TcpOptions};
+pub use tcp_options::{ApplyTcpOptionsError, ApplyTcpOptionsErrorKind, TcpOptions};
 
 /// Helper trait for `Result<Infallible, E>` types. Allows getting the `E` value
 /// in a way that is guaranteed to not panic.


### PR DESCRIPTION
As discussed in the office. Having errors simply be public enums with associated data makes the implementation details part of the public API. Then almost all changes to the error are breaking changes. Here I show two potential ways to implement errors so that their internals are hidden, but it's equally easy to match for a library consumer.

This is currently split into two commits, one per proposed solution. So view it per commit if you want to compare them. I personally like the second solution the best. That error implementation could fairly easily be generated by a macro. I'm sure we are not the first people to come to this conclusion, maybe there is such a macro crate on crates.io already?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/57)
<!-- Reviewable:end -->
