### PR TITLE
Use <[T]>::split_at_checked instead of two separate get calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           - os: ubuntu-latest
             # MSRV. Not considered breaking when this has to be bumped.
             # But update `rust-version` in `Cargo.toml`
-            rust: 1.77.0
+            rust: 1.80.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Tunnel UDP traffic inside a TCP stream. Each datagram is prefixed with a 16 bit unsigned integer containing the length"
 repository = "https://github.com/mullvad/udp-over-tcp"
 edition = "2021"
-rust-version = "1.77.0"
+rust-version = "1.80.0"
 publish = false
 
 [[bin]]

--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -127,12 +127,7 @@ fn split_first_datagram(buffer: &[u8]) -> Option<(&[u8], &[u8])> {
     let (header, tail) = buffer.split_first_chunk::<HEADER_LEN>()?;
     let datagram_len = usize::from(u16::from_be_bytes(*header));
 
-    // TODO: These two get calls (and thus double bounds check) can be replaced with
-    // `split_at_checked` when stabilized: https://github.com/rust-lang/rust/issues/119128
-    let datagram_data = tail.get(..datagram_len)?;
-    let tail = tail.get(datagram_len..)?;
-
-    Some((datagram_data, tail))
+    tail.split_at_checked(datagram_len)
 }
 
 /// Reads datagrams from `udp_in` and writes them (with the 16 bit header containing the length)


### PR DESCRIPTION
Simplifies the code primarily. Probably allows for sliiightly more optimized code when compiling without optimizations also (?) For opt-level=3 the result is the same as before.

This split method was stabilized in Rust 1.80, released yesterday. But we don't need to support any old compilers. We are also not aiming for a release of this program/library right away. This is just a cleanup I have been wanting to do for a long time :D

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/64)
<!-- Reviewable:end -->
