### PR TITLE
Add public constant for header size

### DIFF
--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -21,7 +21,7 @@ use tokio::time::timeout;
 /// read operation would ever return. We are going to use that extra space
 /// to store our 2 byte udp-over-tcp header.
 pub const MAX_DATAGRAM_SIZE: usize = u16::MAX as usize;
-const HEADER_LEN: usize = mem::size_of::<u16>();
+pub const HEADER_LEN: usize = mem::size_of::<u16>();
 
 /// Forward traffic between the given UDP and TCP sockets in both directions.
 /// This async function runs until one of the sockets are closed or there is an error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,9 @@ mod tcp_options;
 
 pub use tcp_options::{ApplyTcpOptionsError, ApplyTcpOptionsErrorKind, TcpOptions};
 
+/// Size of the header (in bytes) that is prepended to each datagram in the TCP stream.
+pub use forward_traffic::HEADER_LEN;
+
 /// Helper trait for `Result<Infallible, E>` types. Allows getting the `E` value
 /// in a way that is guaranteed to not panic.
 pub trait NeverOkResult<E> {


### PR DESCRIPTION
Currently, the Mullvad app is forced to assume that the header is 2 bytes long: https://github.com/mullvad/mullvadvpn-app/blob/f72944e5fe88cb954a93da7bd2a868eb75c445ae/tunnel-obfuscation/src/udp2tcp.rs#L94

That's fine, because the protocol will never change, but it would be slightly cleaner to have a constant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/66)
<!-- Reviewable:end -->
