### PR TITLE
Remove custom NeverOkResult trait and instead use new Rust 1.82 matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           - os: ubuntu-latest
             # MSRV. Not considered breaking when this has to be bumped.
             # But update `rust-version` in `Cargo.toml`
-            rust: 1.80.0
+            rust: 1.82.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Tunnel UDP traffic inside a TCP stream. Each datagram is prefixed with a 16 bit unsigned integer containing the length"
 repository = "https://github.com/mullvad/udp-over-tcp"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 publish = false
 
 [[bin]]

--- a/src/bin/tcp2udp.rs
+++ b/src/bin/tcp2udp.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use err_context::ErrorExt as _;
 use std::num::NonZeroU8;
 
-use udp_over_tcp::{tcp2udp, NeverOkResult};
+use udp_over_tcp::tcp2udp;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -30,9 +30,7 @@ fn main() {
 
     let runtime = create_runtime(options.threads);
 
-    let error = runtime
-        .block_on(tcp2udp::run(options.tcp2udp_options))
-        .into_error();
+    let Err(error) = runtime.block_on(tcp2udp::run(options.tcp2udp_options));
     log::error!("Error: {}", error.display("\nCaused by: "));
     std::process::exit(1);
 }

--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -1,4 +1,3 @@
-use crate::NeverOkResult;
 use err_context::BoxedErrorExt as _;
 use err_context::ResultExt as _;
 use futures::future::select;
@@ -41,7 +40,7 @@ pub async fn process_udp_over_tcp(
         }
     };
     let udp2tcp = async move {
-        let error = process_udp2tcp(udp_in, tcp_out).await.into_error();
+        let Err(error) = process_udp2tcp(udp_in, tcp_out).await;
         log::error!("Error: {}", error.display("\nCaused by: "));
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,15 +95,3 @@ pub use tcp_options::{ApplyTcpOptionsError, ApplyTcpOptionsErrorKind, TcpOptions
 
 /// Size of the header (in bytes) that is prepended to each datagram in the TCP stream.
 pub use forward_traffic::HEADER_LEN;
-
-/// Helper trait for `Result<Infallible, E>` types. Allows getting the `E` value
-/// in a way that is guaranteed to not panic.
-pub trait NeverOkResult<E> {
-    fn into_error(self) -> E;
-}
-
-impl<E> NeverOkResult<E> for Result<std::convert::Infallible, E> {
-    fn into_error(self) -> E {
-        self.expect_err("Result<Infallible, _> can't be Ok variant")
-    }
-}


### PR DESCRIPTION
In Rust 1.82 we finally get to omit impossible branches in pattern matching: https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#omitting-empty-types-in-pattern-matching

This PR utilize that in order to get rid of the custom `NeverOkResult` trait.

This is not an important change, nor is it a high priority. We might want to wait with merging this until we use Rust 1.82 in the main repo. Just so we don't block ourselves from upgrading to the latest `udp-over-tcp` in case we need it. I just realized this potential cleanup and wanted to submit a PR while I had it on the top of my mind :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/69)
<!-- Reviewable:end -->
