### PR TITLE
RFC: add socks5 proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -184,6 +184,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -573,6 +579,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +628,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "udp-over-tcp"
 version = "0.4.0"
 dependencies = [
@@ -613,6 +651,7 @@ dependencies = [
  "log",
  "nix",
  "tokio",
+ "tokio-socks",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,13 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "time
 err-context = "0.1.0"
 log = "0.4.11"
 futures = "0.3.31"
-clap = { version = "4.0", features = ["derive"], optional = true }
+clap = { version = "4.5", features = ["derive", "env"], optional = true }
 
 # Only used by the binaries in src/bin/ and is optional so it's not
 # pulled in when built as a library.
 env_logger = { version = "0.11.3", optional = true }
 cadence = { version = "1.0.0", optional = true }
+tokio-socks = "0.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.27.1", features = ["socket"] }

--- a/src/bin/udp2tcp.rs
+++ b/src/bin/udp2tcp.rs
@@ -21,6 +21,10 @@ pub struct Options {
     #[arg(long = "tcp-forward")]
     pub tcp_forward_addr: SocketAddr,
 
+    /// The socks server to use for forwarding TCP traffic
+    #[arg(long = "socks-server", env = "MULLVAD_UDP_OVER_TCP_SOCKS_SERVER")]
+    pub socks_server_addr: Option<SocketAddr>,
+
     #[clap(flatten)]
     pub tcp_options: udp_over_tcp::TcpOptions,
 }
@@ -41,6 +45,7 @@ async fn run(options: Options) -> Result<(), Box<dyn std::error::Error>> {
     let udp2tcp = udp2tcp::Udp2Tcp::new(
         options.udp_listen_addr,
         options.tcp_forward_addr,
+        options.socks_server_addr,
         options.tcp_options,
     )
     .await?;

--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -5,7 +5,14 @@ use crate::logging::Redact;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
+use tokio::net::TcpStream;
 use tokio::net::{TcpSocket, UdpSocket};
+
+use tokio_socks::{
+    tcp::Socks5Stream,
+    TargetAddr,
+    Error as SocksError,
+};
 
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -25,6 +32,8 @@ pub enum Error {
     ConnectUdp(io::Error),
     /// Failed to connect TCP socket to forward address.
     ConnectTcp(io::Error),
+    /// Failed to forward over SOCKS
+    ConnectSocks(SocksError)
 }
 
 impl fmt::Display for Error {
@@ -37,6 +46,7 @@ impl fmt::Display for Error {
             ReadUdp(_) => "Failed receiving the first UDP datagram".fmt(f),
             ConnectUdp(_) => "Failed to connect UDP socket to peer".fmt(f),
             ConnectTcp(_) => "Failed to connect to TCP forward address".fmt(f),
+            ConnectSocks(_) => "Failed to forward over SOCKS".fmt(f)
         }
     }
 }
@@ -51,6 +61,7 @@ impl std::error::Error for Error {
             ReadUdp(e) => Some(e),
             ConnectUdp(e) => Some(e),
             ConnectTcp(e) => Some(e),
+            ConnectSocks(e) => Some(e),
         }
     }
 }
@@ -60,7 +71,17 @@ pub struct Udp2Tcp {
     tcp_socket: TcpSocket,
     udp_socket: UdpSocket,
     tcp_forward_addr: SocketAddr,
+    socks_server_addr: Option<SocketAddr>,
     tcp_options: crate::TcpOptions,
+}
+
+async fn socks_connect_socket(sock: TcpStream, target: SocketAddr) -> Result<TcpStream, Error> {
+    log::info!("Connecting to {}/SOCKS", target);
+    let socks_tgt = TargetAddr::Ip(target);
+    let socks_sock = Socks5Stream::connect_with_socket(sock, socks_tgt).await.map_err(Error::ConnectSocks)?;
+    let raw_socks_stream = socks_sock.into_inner();
+    log::info!("Connected to {}/SOCKS", target);
+    return Ok(raw_socks_stream);
 }
 
 impl Udp2Tcp {
@@ -69,9 +90,16 @@ impl Udp2Tcp {
     pub async fn new(
         udp_listen_addr: SocketAddr,
         tcp_forward_addr: SocketAddr,
+        socks_server_addr: Option<SocketAddr>,
         tcp_options: crate::TcpOptions,
     ) -> Result<Self, Error> {
-        let tcp_socket = match &tcp_forward_addr {
+        //We'll connect to proxy when proxy is provided, directly to upstream otherwise
+        let upstream_addr: SocketAddr = match socks_server_addr {
+            Some(a) => a,
+            None => tcp_forward_addr
+        };
+
+        let tcp_socket = match &upstream_addr {
             SocketAddr::V4(..) => TcpSocket::new_v4(),
             SocketAddr::V6(..) => TcpSocket::new_v6(),
         }
@@ -91,6 +119,7 @@ impl Udp2Tcp {
             tcp_socket,
             udp_socket,
             tcp_forward_addr,
+            socks_server_addr,
             tcp_options,
         })
     }
@@ -121,16 +150,25 @@ impl Udp2Tcp {
             .map_err(Error::ReadUdp)?;
         log::info!("Incoming connection from {}/UDP", Redact(udp_peer_addr));
 
-        log::info!("Connecting to {}/TCP", self.tcp_forward_addr);
+        let upstream_addr: SocketAddr = match self.socks_server_addr {
+            Some(a) => a,
+            None => self.tcp_forward_addr
+        };
+
+        log::info!("Connecting to {}/TCP", upstream_addr);
         let tcp_stream = self
             .tcp_socket
-            .connect(self.tcp_forward_addr)
+            .connect(upstream_addr)
             .await
             .map_err(Error::ConnectTcp)?;
-        log::info!("Connected to {}/TCP", self.tcp_forward_addr);
-
+        log::info!("Connected to {}/TCP", upstream_addr);
         crate::tcp_options::set_nodelay(&tcp_stream, self.tcp_options.nodelay)
             .map_err(Error::ApplyTcpOptions)?;
+
+        let final_stream = match self.socks_server_addr {
+          None => tcp_stream,
+          Some(_) => {socks_connect_socket(tcp_stream, self.tcp_forward_addr).await?}
+        };
 
         // Connect the UDP socket to whoever sent the first datagram. This is where
         // all the returned traffic will be sent to.
@@ -141,7 +179,7 @@ impl Udp2Tcp {
 
         crate::forward_traffic::process_udp_over_tcp(
             self.udp_socket,
-            tcp_stream,
+            final_stream,
             self.tcp_options.recv_timeout,
         )
         .await;

--- a/tests/udp2tcp.rs
+++ b/tests/udp2tcp.rs
@@ -123,6 +123,7 @@ async fn setup_udp2tcp() -> Result<
     let udp2tcp = udp2tcp::Udp2Tcp::new(
         "127.0.0.1:0".parse().unwrap(),
         tcp_listen_addr,
+        None,
         TcpOptions::default(),
     )
     .await?;


### PR DESCRIPTION
Sometimes, I end up in a situation where I need to connect to VPN through a SOCKS proxy. I would rather not describe the exact specifics, but basically the only way to connect to the Internet is through the said proxy. This can also be useful for easily adding additional censorship circumvention methods (like connecting over Tor, websockets, SSH tunnel etc).

This PR adds support for SOCKS connections to udp2tcp using the `tokio-socks` crate. Please note that this is a breaking change, because it changes the arguments expected by `Udp2Tcp::new`.

This version _seems_ to  work fine, in fact, I am writing this while connected to Mullvad through this setup.

This does not add any support to the larger app, to connect, you can patch it using the attached patch, build the daemon normally, and then run the daemon with `sudo env RUST_LOG=info MULLVAD_UDP_OVER_TCP_SOCKS_SERVER=127.0.0.1:13000 MULLVAD_RESOURCE_DIR="./dist-assets" TALPID_DISABLE_OFFLINE_MONITOR=1 ./target/debug/mullvad-daemon -vv`

Patch: [mullvad_app_socks.patch](https://github.com/user-attachments/files/24685414/mullvad_app_socks.patch)

If there's interest, I think I can work on adding the support to the larger app, but the task seems quite a bit daunting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/81)
<!-- Reviewable:end -->
