### PR TITLE
Add method for retrieving raw TCP socket on Windows

### DIFF
--- a/src/udp2tcp.rs
+++ b/src/udp2tcp.rs
@@ -109,6 +109,13 @@ impl Udp2Tcp {
         self.tcp_socket.as_raw_fd()
     }
 
+    /// Returns the raw TCP socket that datagrams are forwarded to.
+    #[cfg(windows)]
+    pub fn remote_tcp_socket(&self) -> std::os::windows::io::RawSocket {
+        use std::os::windows::io::AsRawSocket;
+        self.tcp_socket.as_raw_socket()
+    }
+
     /// Connects to the TCP address and runs the forwarding until the TCP socket is closed, or
     /// an error occur.
     pub async fn run(self) -> Result<(), Error> {


### PR DESCRIPTION
Add Windows equivalent to `Udp2Tcp::remote_tcp_fd`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/84)
<!-- Reviewable:end -->
