### PR TITLE
Make `process_udp_over_tcp` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Expose `process_udp_over_tcp`. Allows forwarding traffic between a UDP and a TCP socket that the
   caller set up themselves, instead of going through `Udp2Tcp`.
+- Add the `DatagramSocket` trait and make `process_udp_over_tcp` generic over it. Allows tunneling
+  datagrams from any transport, and not just real UDP sockets, over the TCP stream.
 
 ### Changed
 - Change the public API of `ApplyTcpOptionsError`. So this is a breaking change. This stops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Expose `process_udp_over_tcp`. Allows forwarding traffic between a UDP and a TCP socket that the
+  caller set up themselves, instead of going through `Udp2Tcp`.
+
 ### Changed
 - Change the public API of `ApplyTcpOptionsError`. So this is a breaking change. This stops
   exposing the internal details of the type which allows future changes to not be breaking.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ cadence = { version = "1.0.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.31.2", features = ["socket"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", default-features = false, features = ["sync"] }

--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -24,6 +24,7 @@ pub const HEADER_LEN: usize = mem::size_of::<u16>();
 
 /// Forward traffic between the given UDP and TCP sockets in both directions.
 /// This async function runs until one of the sockets are closed or there is an error.
+/// Both sockets must be connected to their respective peers.
 /// Both sockets are closed before returning.
 pub async fn process_udp_over_tcp(
     udp_socket: UdpSocket,

--- a/src/forward_traffic.rs
+++ b/src/forward_traffic.rs
@@ -6,7 +6,6 @@ use std::convert::Infallible;
 use std::future::Future;
 use std::io;
 use std::mem;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf as TcpReadHalf, OwnedWriteHalf as TcpWriteHalf};
@@ -22,26 +21,46 @@ use tokio::time::timeout;
 pub const MAX_DATAGRAM_SIZE: usize = u16::MAX as usize;
 pub const HEADER_LEN: usize = mem::size_of::<u16>();
 
-/// Forward traffic between the given UDP and TCP sockets in both directions.
+/// A connected datagram transport.
+pub trait DatagramSocket {
+    /// Sends one datagram to the peer this socket is connected to. Returns the number of
+    /// bytes sent, which must be the length of the entire datagram.
+    fn send(&self, buf: &[u8]) -> impl Future<Output = io::Result<usize>> + Send;
+
+    /// Receives one datagram from the peer this socket is connected to, and returns its
+    /// length. Must never return more than [`MAX_DATAGRAM_SIZE`], since the length header
+    /// in the TCP stream is only 16 bits.
+    fn recv(&self, buf: &mut [u8]) -> impl Future<Output = io::Result<usize>> + Send;
+}
+
+impl DatagramSocket for UdpSocket {
+    fn send(&self, buf: &[u8]) -> impl Future<Output = io::Result<usize>> + Send {
+        UdpSocket::send(self, buf)
+    }
+
+    fn recv(&self, buf: &mut [u8]) -> impl Future<Output = io::Result<usize>> + Send {
+        UdpSocket::recv(self, buf)
+    }
+}
+
+/// Forward traffic between the given UDP socket and TCP socket in both directions.
 /// This async function runs until one of the sockets are closed or there is an error.
 /// Both sockets must be connected to their respective peers.
 /// Both sockets are closed before returning.
-pub async fn process_udp_over_tcp(
-    udp_socket: UdpSocket,
+pub async fn process_udp_over_tcp<S: DatagramSocket>(
+    udp_socket: S,
     tcp_stream: TcpStream,
     tcp_recv_timeout: Option<Duration>,
 ) {
-    let udp_in = Arc::new(udp_socket);
-    let udp_out = udp_in.clone();
     let (tcp_in, tcp_out) = tcp_stream.into_split();
 
-    let tcp2udp = async move {
-        if let Err(error) = process_tcp2udp(tcp_in, udp_out, tcp_recv_timeout).await {
+    let tcp2udp = async {
+        if let Err(error) = process_tcp2udp(tcp_in, &udp_socket, tcp_recv_timeout).await {
             log::error!("Error: {}", error.display("\nCaused by: "));
         }
     };
-    let udp2tcp = async move {
-        let Err(error) = process_udp2tcp(udp_in, tcp_out).await;
+    let udp2tcp = async {
+        let Err(error) = process_udp2tcp(&udp_socket, tcp_out).await;
         log::error!("Error: {}", error.display("\nCaused by: "));
     };
 
@@ -56,7 +75,7 @@ pub async fn process_udp_over_tcp(
 /// Returns if the TCP socket is closed, or an IO error happens on either socket.
 async fn process_tcp2udp(
     mut tcp_in: TcpReadHalf,
-    udp_out: Arc<UdpSocket>,
+    udp_out: &impl DatagramSocket,
     tcp_recv_timeout: Option<Duration>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut buffer = datagram_buffer();
@@ -73,7 +92,7 @@ async fn process_tcp2udp(
         }
         unprocessed_i += tcp_read_len;
 
-        let processed_i = forward_datagrams_in_buffer(&udp_out, &buffer[..unprocessed_i])
+        let processed_i = forward_datagrams_in_buffer(udp_out, &buffer[..unprocessed_i])
             .await
             .context("Failed writing to UDP")?;
 
@@ -100,7 +119,10 @@ async fn maybe_timeout<F: Future>(
 
 /// Forward all complete datagrams in `buffer` to `udp_out`.
 /// Returns the number of processed bytes.
-async fn forward_datagrams_in_buffer(udp_out: &UdpSocket, buffer: &[u8]) -> io::Result<usize> {
+async fn forward_datagrams_in_buffer(
+    udp_out: &impl DatagramSocket,
+    buffer: &[u8],
+) -> io::Result<usize> {
     let mut unprocessed_buffer = buffer;
     loop {
         let Some((datagram_data, tail)) = split_first_datagram(unprocessed_buffer) else {
@@ -133,7 +155,7 @@ fn split_first_datagram(buffer: &[u8]) -> Option<(&[u8], &[u8])> {
 /// Reads datagrams from `udp_in` and writes them (with the 16 bit header containing the length)
 /// to `tcp_out` indefinitely, or until an IO error happens on either socket.
 async fn process_udp2tcp(
-    udp_in: Arc<UdpSocket>,
+    udp_in: &impl DatagramSocket,
     mut tcp_out: TcpWriteHalf,
 ) -> Result<Infallible, Box<dyn std::error::Error>> {
     // A buffer large enough to hold any possible UDP datagram plus its 16 bit length header.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,3 +95,5 @@ pub use tcp_options::{ApplyTcpOptionsError, ApplyTcpOptionsErrorKind, TcpOptions
 
 /// Size of the header (in bytes) that is prepended to each datagram in the TCP stream.
 pub use forward_traffic::HEADER_LEN;
+
+pub use forward_traffic::process_udp_over_tcp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,4 +96,4 @@ pub use tcp_options::{ApplyTcpOptionsError, ApplyTcpOptionsErrorKind, TcpOptions
 /// Size of the header (in bytes) that is prepended to each datagram in the TCP stream.
 pub use forward_traffic::HEADER_LEN;
 
-pub use forward_traffic::process_udp_over_tcp;
+pub use forward_traffic::{DatagramSocket, process_udp_over_tcp};

--- a/tests/custom_datagram_socket.rs
+++ b/tests/custom_datagram_socket.rs
@@ -1,0 +1,93 @@
+//! Tests that [`process_udp_over_tcp`] can tunnel datagrams from something else
+//! than an actual UDP socket.
+
+use std::io;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, mpsc};
+use udp_over_tcp::{DatagramSocket, process_udp_over_tcp};
+
+/// An in-memory datagram transport. Datagrams sent by the forwarder end up in `outgoing`,
+/// and datagrams pushed into `incoming` are received by the forwarder.
+struct ChannelSocket {
+    outgoing: mpsc::UnboundedSender<Vec<u8>>,
+    incoming: Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
+}
+
+impl DatagramSocket for ChannelSocket {
+    async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.outgoing
+            .send(buf.to_vec())
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?;
+        Ok(buf.len())
+    }
+
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut incoming = self.incoming.lock().await;
+        let datagram = incoming
+            .recv()
+            .await
+            .ok_or(io::Error::from(io::ErrorKind::BrokenPipe))?;
+        buf[..datagram.len()].copy_from_slice(&datagram);
+        Ok(datagram.len())
+    }
+}
+
+/// Send one datagram transport->TCP and one back TCP->transport.
+#[tokio::test]
+async fn ping_pong() -> Result<(), Box<dyn std::error::Error>> {
+    let (to_forwarder, mut from_forwarder, mut tcp_stream) = setup().await?;
+    let mut buffer = [0; 1024];
+
+    // Send a datagram into the forwarder and assert it comes out
+    // the TCP socket with the correct format.
+    {
+        to_forwarder.send(vec![1, 2, 3])?;
+
+        let read_len = tcp_stream.read(&mut buffer[..]).await?;
+        assert_eq!(read_len, 5);
+        // Big endian header
+        assert_eq!(&buffer[0..2], &[0, 3]);
+        // Datagram body
+        assert_eq!(&buffer[2..5], &[1, 2, 3]);
+    }
+
+    // Send an encoded datagram down the TCP socket and assert it comes
+    // back out of the transport as a single datagram.
+    {
+        // Write big endian header
+        tcp_stream.write_all(&[0u8, 2]).await?;
+        // Write datagram body
+        tcp_stream.write_all(&[9, 8]).await?;
+
+        assert_eq!(from_forwarder.recv().await, Some(vec![9, 8]));
+    }
+    Ok(())
+}
+
+/// Spawns a forwarder between a [`ChannelSocket`] and a TCP socket. Returns the two
+/// ends of the transport plus the other end of the TCP connection.
+async fn setup() -> Result<
+    (
+        mpsc::UnboundedSender<Vec<u8>>,
+        mpsc::UnboundedReceiver<Vec<u8>>,
+        TcpStream,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let tcp_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let tcp_stream = TcpStream::connect(tcp_listener.local_addr()?).await?;
+    let forwarder_tcp_stream = tcp_listener.accept().await?.0;
+
+    let (to_forwarder, incoming) = mpsc::unbounded_channel();
+    let (outgoing, from_forwarder) = mpsc::unbounded_channel();
+    let socket = ChannelSocket {
+        outgoing,
+        incoming: Mutex::new(incoming),
+    };
+
+    // Spawning also asserts that the forwarder future is `Send`.
+    tokio::spawn(process_udp_over_tcp(socket, forwarder_tcp_stream, None));
+
+    Ok((to_forwarder, from_forwarder, tcp_stream))
+}

--- a/tests/udp2tcp.rs
+++ b/tests/udp2tcp.rs
@@ -1,7 +1,7 @@
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::task::JoinHandle;
-use udp_over_tcp::{TcpOptions, udp2tcp};
+use udp_over_tcp::{HEADER_LEN, TcpOptions, udp2tcp};
 
 /// Set everything up and then close the TCP socket. That should cleanly make the Udp2Tcp
 /// instance shut down.
@@ -136,8 +136,10 @@ async fn setup_udp2tcp() -> Result<
     // Send empty datagram to connect TCP socket
     udp_socket.send(&[]).await?;
     let mut tcp_stream = tcp_listener.accept().await?.0;
-    let mut buf = [0; 1024];
-    tcp_stream.read(&mut buf).await?;
+    // Read out the empty datagram. It is just the length header, with no body.
+    let mut header = [0; HEADER_LEN];
+    tcp_stream.read_exact(&mut header).await?;
+    assert_eq!(header, [0, 0]);
 
     Ok((udp_socket, tcp_stream, join_handle))
 }


### PR DESCRIPTION
This is useful for running udp2tcp on already-connected sockets.

Also made it generic so that it doesn't have to use an actual UDP socket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/udp-over-tcp/85)
<!-- Reviewable:end -->
